### PR TITLE
Use portable interpreter directives

### DIFF
--- a/dumptable
+++ b/dumptable
@@ -1,4 +1,4 @@
-#!env python3
+#!/usr/bin/env python3
 from fontTools.ttLib import TTFont
 import argparse
 import sys

--- a/fontshell
+++ b/fontshell
@@ -1,4 +1,4 @@
-#!env python3
+#!/usr/bin/env python3
 from fontTools.ttLib import TTFont
 import sys
 

--- a/interrofont
+++ b/interrofont
@@ -1,4 +1,4 @@
-#!env python3
+#!/usr/bin/env python3
 import sys
 from fontTools.ttLib import TTFont
 from argparse import ArgumentParser


### PR DESCRIPTION
The executable Python scripts use `#!env python3` as a hashbang. Not sure if this works on Linux, but on macOS and *BSD, it simply doesn't execute (or even worse, gets executed as a shell-script instead of Python).

This PR remedies that.